### PR TITLE
fixed null errors on view book page

### DIFF
--- a/book-recommendations/frontend/src/components/viewbook/AboutBook.vue
+++ b/book-recommendations/frontend/src/components/viewbook/AboutBook.vue
@@ -5,7 +5,10 @@
     </h3>
     <v-card class="pa-4">
       <v-row>
-        <v-col cols="3">
+        <v-col
+          v-if="category"
+          cols="3"
+        >
           <p>
             Genre:
           </p>
@@ -15,7 +18,10 @@
             {{ categories }}
           </p>
         </v-col>
-        <v-col cols="3">
+        <v-col
+          v-if="publisher"
+          cols="3"
+        >
           <p>
             Publisher:
           </p>
@@ -27,7 +33,10 @@
         </v-col>
       </v-row>
       <v-row class="mt-0">
-        <v-col cols="3">
+        <v-col
+          v-if="publishedDate"
+          cols="3"
+        >
           <p>
             Published date:
           </p>
@@ -37,7 +46,10 @@
             {{ formatDate() }}
           </p>
         </v-col>
-        <v-col cols="3">
+        <v-col
+          v-if="pages"
+          cols="3"
+        >
           <p>
             Number of pages:
           </p>
@@ -56,7 +68,10 @@
           {{ description }}
         </p>
         <v-layout justify-center>
-          <v-card-actions class="mb-5">
+          <v-card-actions
+            v-if="originalDescription"
+            class="mb-5"
+          >
             <v-btn
               v-if="isShortDescription"
               @click="viewWholeDescription"
@@ -77,7 +92,6 @@
 </template>
 
 <script>
-
 export default {
   name: "AboutBook",
   props: {

--- a/book-recommendations/frontend/src/pages/ViewBookPage.vue
+++ b/book-recommendations/frontend/src/pages/ViewBookPage.vue
@@ -80,7 +80,7 @@
         :published-date="bookData.publishedDate"
         :original-description="bookData.description"
         :pages="bookData.pageCount"
-        :publisher="bookData.publisher.toString()"
+        :publisher="bookData.publisher"
       />
     </v-row>
   </v-container>


### PR DESCRIPTION
There was erorrs with null descriptions, page count and publisher. Now doesn't show the View more button if the description if null or the "Page count" or "Publisher" bits if they're null. 

Also error that I mentioned with the jk rowling ickabog and christmas pig books is fixed. It was stuck on loading as there was a publisher.toString() call but when the publisher was null it errored. 