### PR TITLE
added caching

### DIFF
--- a/book-recommendations/src/main/java/com/bestreads/bookrecommendations/nytimesapi/NyTimesCacheConfig.java
+++ b/book-recommendations/src/main/java/com/bestreads/bookrecommendations/nytimesapi/NyTimesCacheConfig.java
@@ -1,0 +1,17 @@
+package com.bestreads.bookrecommendations.nytimesapi;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+class NyTimesCacheConfig {
+
+  @Bean
+  public CacheManager cacheManager() {
+    return new ConcurrentMapCacheManager("best-sellers");
+  }
+}

--- a/book-recommendations/src/main/java/com/bestreads/bookrecommendations/nytimesapi/NyTimesCacheCustomizer.java
+++ b/book-recommendations/src/main/java/com/bestreads/bookrecommendations/nytimesapi/NyTimesCacheCustomizer.java
@@ -1,0 +1,15 @@
+package com.bestreads.bookrecommendations.nytimesapi;
+
+import java.util.List;
+import org.springframework.boot.autoconfigure.cache.CacheManagerCustomizer;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.stereotype.Component;
+
+@Component
+class NyTimesCacheCustomizer implements CacheManagerCustomizer<ConcurrentMapCacheManager> {
+
+  @Override
+  public void customize(ConcurrentMapCacheManager cacheManager) {
+    cacheManager.setCacheNames(List.of("best-sellers"));
+  }
+}

--- a/book-recommendations/src/main/java/com/bestreads/bookrecommendations/nytimesapi/NyTimesService.java
+++ b/book-recommendations/src/main/java/com/bestreads/bookrecommendations/nytimesapi/NyTimesService.java
@@ -9,6 +9,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.logging.Level;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,12 +25,19 @@ public class NyTimesService {
   @Value("${nytimes.api.key}")
   private String apiKey;
 
+  @Cacheable(value = "best-sellers")
   public HttpResponse<String> getCurrentBestSellers() {
     var uri = "%s/lists/overview.json?api-key=%s".formatted(
         nyTimesApiUri,
         apiKey
     );
     return sendHttpRequest(getGetHttpRequest(uri));
+  }
+
+  @CacheEvict(value = "best-sellers", allEntries = true)
+  @Scheduled(fixedDelayString = "86400000")
+  public void emptyBestSellersCache() {
+    logger.info("emptying best sellers cache");
   }
 
   private HttpRequest getGetHttpRequest(String uri) {


### PR DESCRIPTION
This will hit the ny times api endpoint every 24 hours. Otherwise will access the cache to get the best sellers