### PR TITLE
Update CI workflow to use Azure CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,116 +8,132 @@ on:
 
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
-  build-spring:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - name: 'Az CLI login'
+        uses: azure/login@v1
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-      - name: Setup and execute Gradle 'build' task
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build
-          build-root-directory: book-recommendations
-      - name: Save java test reports
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Spring test report
-          path: book-recommendations/build/reports/tests/test
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-  build-vue:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 'book-recommendations/frontend'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - run: |
-          npm install
-          npm run lint
-          npm run test:unit
-          npm run build
-      - name: Save vue test reports
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Vue test report
-          path: book-recommendations/frontend/test-report/index.html
-
-  publish-to-docker:
-    needs: [ build-spring, build-vue ]
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push spring image
-        uses: docker/build-push-action@v3
-        with:
-          context: ./book-recommendations
-          push: true
-          tags: augmart/book-recommendations-api
-      - name: Build and push vue image
-        uses: docker/build-push-action@v3
-        with:
-          context: ./book-recommendations/frontend
-          push: true
-          tags: augmart/book-recommendations-frontend
-          build-args: |
-            VUE_APP_AUTH0_DOMAIN=${{ secrets.VUE_APP_AUTH0_DOMAIN }}
-            VUE_APP_AUTH0_CLIENT_ID=${{ secrets.VUE_APP_AUTH0_CLIENT_ID }}
-
-  deploy-to-aws:
-    needs: [ publish-to-docker ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Generate deployment package
+      - name: 'Run Azure CLI commands'
         run: |
-          cd book-recommendations
-          zip -r deploy.zip . -x '*.git*'
-      - name: Get timestamp
-        uses: gerred/actions/current-time@master
-        id: current-time
-      - name: Run string replace
-        uses: frabert/replace-string-action@v2
-        id: format-time
-        with:
-          pattern: '[:\.]+'
-          string: "${{ steps.current-time.outputs.time }}"
-          replace-with: '-'
-          flags: 'g'
-      - name: Deploy to EB
-        uses: einaregilsson/beanstalk-deploy@v21
-        with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
-          application_name: bookrecommendations
-          environment_name: Bookrecommendations-env
-          version_label: "best-reads-test-${{ steps.format-time.outputs.replaced }}"
-          region: eu-west-2
-          deployment_package: book-recommendations/deploy.zip
+          az account show
+          az group list
+          pwd
+#  build-spring:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#          cache: 'gradle'
+#      - name: Setup and execute Gradle 'build' task
+#        uses: gradle/gradle-build-action@v2
+#        with:
+#          arguments: build
+#          build-root-directory: book-recommendations
+#      - name: Save java test reports
+#        if: success() || failure()
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: Spring test report
+#          path: book-recommendations/build/reports/tests/test
+#
+#  build-vue:
+#    runs-on: ubuntu-latest
+#    defaults:
+#      run:
+#        working-directory: 'book-recommendations/frontend'
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Setup node
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: 16
+#          cache: 'npm'
+#          cache-dependency-path: '**/package-lock.json'
+#      - run: |
+#          npm install
+#          npm run lint
+#          npm run test:unit
+#          npm run build
+#      - name: Save vue test reports
+#        if: success() || failure()
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: Vue test report
+#          path: book-recommendations/frontend/test-report/index.html
+#
+#  publish-to-docker:
+#    needs: [ build-spring, build-vue ]
+#    runs-on: ubuntu-latest
+#    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v2
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v2
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v2
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      - name: Build and push spring image
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: ./book-recommendations
+#          push: true
+#          tags: augmart/book-recommendations-api
+#      - name: Build and push vue image
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: ./book-recommendations/frontend
+#          push: true
+#          tags: augmart/book-recommendations-frontend
+#          build-args: |
+#            VUE_APP_AUTH0_DOMAIN=${{ secrets.VUE_APP_AUTH0_DOMAIN }}
+#            VUE_APP_AUTH0_CLIENT_ID=${{ secrets.VUE_APP_AUTH0_CLIENT_ID }}
+#
+#  deploy-to-aws:
+#    needs: [ publish-to-docker ]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#      - name: Generate deployment package
+#        run: |
+#          cd book-recommendations
+#          zip -r deploy.zip . -x '*.git*'
+#      - name: Get timestamp
+#        uses: gerred/actions/current-time@master
+#        id: current-time
+#      - name: Run string replace
+#        uses: frabert/replace-string-action@v2
+#        id: format-time
+#        with:
+#          pattern: '[:\.]+'
+#          string: "${{ steps.current-time.outputs.time }}"
+#          replace-with: '-'
+#          flags: 'g'
+#      - name: Deploy to EB
+#        uses: einaregilsson/beanstalk-deploy@v21
+#        with:
+#          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+#          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
+#          application_name: bookrecommendations
+#          environment_name: Bookrecommendations-env
+#          version_label: "best-reads-test-${{ steps.format-time.outputs.replaced }}"
+#          region: eu-west-2
+#          deployment_package: book-recommendations/deploy.zip


### PR DESCRIPTION
Removed the build and deployment jobs for spring, vue, publish-to-docker, and deploy-to-aws in the Github Actions workflow. Replaced these jobs with build-and-deploy job that utilizes Azure CLI to login and run Azure related commands. This is in preparation for the migration of the project to Azure infrastructure.